### PR TITLE
모임일 관련 API 작성/수정

### DIFF
--- a/src/docs/asciidoc/meeting/index.adoc
+++ b/src/docs/asciidoc/meeting/index.adoc
@@ -60,3 +60,5 @@ include::meeting-date-confirm.adoc[]
 include::meeting-date-cancel.adoc[]
 
 include::meeting-confirmed-date-simple.adoc[]
+
+include::meeting-fixed-date-list.adoc[]

--- a/src/docs/asciidoc/meeting/index.adoc
+++ b/src/docs/asciidoc/meeting/index.adoc
@@ -57,4 +57,6 @@ include::voting-details.adoc[]
 == 모임일 확정 API
 include::meeting-date-confirm.adoc[]
 
+include::meeting-date-cancel.adoc[]
+
 include::meeting-confirmed-date-simple.adoc[]

--- a/src/docs/asciidoc/meeting/meeting-date-cancel.adoc
+++ b/src/docs/asciidoc/meeting/meeting-date-cancel.adoc
@@ -1,0 +1,35 @@
+:doctype: book
+:icons: font
+:sectlinks:
+:docinfo: shared-head
+
+[[meeting-date-cancel]]
+=== 모임일 취소
+
+DELETE /api/v1/meetings/{meeting-id}/date/confirm
+
+==== API Spec
+*경로 파라미터*
+
+include::{snippets}/meeting-date-cancel/success/path-parameters.adoc[]
+
+*요청 헤더*
+
+include::{snippets}/meeting-date-cancel/success/request-headers.adoc[]
+
+*응답 필드*
+
+include::{snippets}/meeting-date-cancel/success/response-fields.adoc[]
+
+==== 요청/응답 예시
+*요청 예시*
+
+include::{snippets}/meeting-date-cancel/success/http-request.adoc[]
+
+*응답 예시*
+
+include::{snippets}/meeting-date-cancel/success/http-response.adoc[]
+
+오류 발생시 아래 "오류 코드 확인하기" 링크에서 모임 관련 오류(`3XXX`)를 확인해주세요.
+
+* link:../errors/error-code.html[오류 코드 확인하기,role="error-code-popup"]

--- a/src/docs/asciidoc/meeting/meeting-fixed-date-list.adoc
+++ b/src/docs/asciidoc/meeting/meeting-fixed-date-list.adoc
@@ -1,0 +1,35 @@
+:doctype: book
+:icons: font
+:sectlinks:
+:docinfo: shared-head
+
+[[meeting-fixed-date-list]]
+=== 확정된 모임일 리스트 조회
+
+GET /api/v1/meetings/date/confirm
+
+==== API Spec
+*요청 파라미터*
+
+include::{snippets}/meeting-confirm-dates/success/request-parameters.adoc[]
+
+*요청 헤더*
+
+include::{snippets}/meeting-confirm-dates/success/request-headers.adoc[]
+
+*응답 필드*
+
+include::{snippets}/meeting-confirm-dates/success/response-fields.adoc[]
+
+==== 요청/응답 예시
+*요청 예시*
+
+include::{snippets}/meeting-confirm-dates/success/http-request.adoc[]
+
+*응답 예시*
+
+include::{snippets}/meeting-confirm-dates/success/http-response.adoc[]
+
+오류 발생시 아래 "오류 코드 확인하기" 링크에서 모임 관련 오류(`3XXX`)를 확인해주세요.
+
+* link:../errors/error-code.html[오류 코드 확인하기,role="error-code-popup"]

--- a/src/main/java/com/comeon/backend/common/error/MeetingErrorCode.java
+++ b/src/main/java/com/comeon/backend/common/error/MeetingErrorCode.java
@@ -20,7 +20,8 @@ public enum MeetingErrorCode implements ErrorCode {
     NO_DATE_VOTING_EXIST(3201, HttpStatus.BAD_REQUEST, "해당 일자에 투표한 이력이 없습니다."),
     DATE_OUT_OF_CALENDAR_RANGE(3202, HttpStatus.BAD_REQUEST, "투표 가능 범위에 해당하지 않는 일자입니다."),
     DATE_RANGE_OUT_OF_CALENDAR_RANGE(3203, HttpStatus.BAD_REQUEST, "모임일 확정 일자가 모임 캘린더 범위에 포함되지 않습니다."),
-    FIXED_DATE_EXIST(3204, HttpStatus.BAD_REQUEST, "이미 지정된 모임일이 존재합니다.")
+    FIXED_DATE_EXIST(3204, HttpStatus.BAD_REQUEST, "이미 지정된 모임일이 존재합니다."),
+    FIXED_DATE_NOT_EXIST(3205, HttpStatus.BAD_REQUEST, "확정된 모임일이 존재하지 않습니다."),
     ;
 
     private final int code;

--- a/src/main/java/com/comeon/backend/date/api/FixedDateApiController.java
+++ b/src/main/java/com/comeon/backend/date/api/FixedDateApiController.java
@@ -2,6 +2,7 @@ package com.comeon.backend.date.api;
 
 import com.comeon.backend.config.web.member.MemberRole;
 import com.comeon.backend.config.web.member.RequiredMemberRole;
+import com.comeon.backend.date.api.dto.MeetingDateCancelResponse;
 import com.comeon.backend.date.api.dto.MeetingDateConfirmResponse;
 import com.comeon.backend.date.command.application.confirm.DateConfirmFacade;
 import com.comeon.backend.date.command.application.confirm.FixedDateAddRequest;
@@ -29,6 +30,15 @@ public class FixedDateApiController {
     ) {
         dateConfirmFacade.confirmMeetingDate(meetingId, request);
         return new MeetingDateConfirmResponse();
+    }
+
+    @RequiredMemberRole(MemberRole.HOST)
+    @DeleteMapping
+    public MeetingDateCancelResponse meetingDateCancel(
+            @PathVariable Long meetingId
+    ) {
+        dateConfirmFacade.cancelMeetingConfirmedDate(meetingId);
+        return new MeetingDateCancelResponse();
     }
 
     @RequiredMemberRole

--- a/src/main/java/com/comeon/backend/date/api/FixedDateListApiController.java
+++ b/src/main/java/com/comeon/backend/date/api/FixedDateListApiController.java
@@ -1,0 +1,32 @@
+package com.comeon.backend.date.api;
+
+import com.comeon.backend.config.security.JwtPrincipal;
+import com.comeon.backend.date.api.dto.MeetingConfirmDatesParam;
+import com.comeon.backend.date.query.application.FixedDateQueryService;
+import com.comeon.backend.date.query.dto.MeetingFixedDatesResponse;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.security.core.annotation.AuthenticationPrincipal;
+import org.springframework.validation.annotation.Validated;
+import org.springframework.web.bind.annotation.*;
+
+@Slf4j
+@RestController
+@RequiredArgsConstructor
+@RequestMapping("/api/v1/meetings/date/confirm")
+public class FixedDateListApiController {
+
+    private final FixedDateQueryService fixedDateQueryService;
+
+    @GetMapping
+    public MeetingFixedDatesResponse meetingConfirmDates(
+            @AuthenticationPrincipal JwtPrincipal jwtPrincipal,
+            @Validated @ModelAttribute MeetingConfirmDatesParam param
+    ) {
+        return fixedDateQueryService.findMeetingFixedDates(
+                jwtPrincipal.getUserId(),
+                param.getYear(),
+                param.getMonth()
+        );
+    }
+}

--- a/src/main/java/com/comeon/backend/date/api/dto/MeetingConfirmDatesParam.java
+++ b/src/main/java/com/comeon/backend/date/api/dto/MeetingConfirmDatesParam.java
@@ -1,0 +1,27 @@
+package com.comeon.backend.date.api.dto;
+
+import lombok.AllArgsConstructor;
+import lombok.NoArgsConstructor;
+import lombok.Setter;
+
+import javax.validation.constraints.Pattern;
+import java.time.LocalDate;
+import java.time.format.DateTimeFormatter;
+
+@Setter
+@NoArgsConstructor
+@AllArgsConstructor
+public class MeetingConfirmDatesParam {
+
+    // TODO "\"^\\d{4}-(0[1-9]|1[012])$\"와 일치해야 합니다" <- 메시지 수정
+    @Pattern(regexp = "^\\d{4}-(0[1-9]|1[012])$")
+    private String calendar = LocalDate.now().format(DateTimeFormatter.ofPattern("yyyy-MM"));
+
+    public int getYear() {
+        return Integer.parseInt(this.calendar.split("-")[0]);
+    }
+
+    public int getMonth() {
+        return Integer.parseInt(this.calendar.split("-")[1]);
+    }
+}

--- a/src/main/java/com/comeon/backend/date/api/dto/MeetingDateCancelResponse.java
+++ b/src/main/java/com/comeon/backend/date/api/dto/MeetingDateCancelResponse.java
@@ -1,0 +1,15 @@
+package com.comeon.backend.date.api.dto;
+
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+
+@Getter
+@AllArgsConstructor
+public class MeetingDateCancelResponse {
+
+    private Boolean success;
+
+    public MeetingDateCancelResponse() {
+        this.success = true;
+    }
+}

--- a/src/main/java/com/comeon/backend/date/command/application/confirm/FixedDateNotExistException.java
+++ b/src/main/java/com/comeon/backend/date/command/application/confirm/FixedDateNotExistException.java
@@ -1,0 +1,14 @@
+package com.comeon.backend.date.command.application.confirm;
+
+import com.comeon.backend.common.error.ErrorCode;
+import com.comeon.backend.common.error.MeetingErrorCode;
+import com.comeon.backend.common.error.RestApiException;
+
+public class FixedDateNotExistException extends RestApiException {
+
+    private static final ErrorCode errorCode = MeetingErrorCode.FIXED_DATE_NOT_EXIST;
+
+    public FixedDateNotExistException() {
+        super(errorCode);
+    }
+}

--- a/src/main/java/com/comeon/backend/date/command/domain/confirm/FixedDate.java
+++ b/src/main/java/com/comeon/backend/date/command/domain/confirm/FixedDate.java
@@ -31,6 +31,11 @@ public class FixedDate extends BaseTimeEntity {
         Events.raise(FixedDateEvent.create(meetingId));
     }
 
+    public void update(LocalDate startFrom, LocalDate endTo) {
+        this.startFrom = startFrom;
+        this.endTo = endTo;
+    }
+
     @Override
     public String toString() {
         return "["

--- a/src/main/java/com/comeon/backend/date/infrastructure/dao/FixedDateDaoImpl.java
+++ b/src/main/java/com/comeon/backend/date/infrastructure/dao/FixedDateDaoImpl.java
@@ -2,8 +2,12 @@ package com.comeon.backend.date.infrastructure.dao;
 
 import com.comeon.backend.date.query.dao.FixedDateDao;
 import com.comeon.backend.date.query.dto.MeetingFixedDateSimple;
+import com.comeon.backend.date.query.dto.MeetingFixedDateSummary;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Component;
+
+import java.time.LocalDate;
+import java.util.List;
 
 @Component
 @RequiredArgsConstructor
@@ -14,5 +18,10 @@ public class FixedDateDaoImpl implements FixedDateDao {
     @Override
     public MeetingFixedDateSimple findFixedDateSimple(Long meetingId) {
         return fixedDateMapper.selectFixedDateSimple(meetingId);
+    }
+
+    @Override
+    public List<MeetingFixedDateSummary> findMeetingFixedDatesSummary(Long userId, LocalDate searchStartFrom, LocalDate searchEndTo) {
+        return fixedDateMapper.selectMeetingFixedDateSummary(userId, searchStartFrom, searchEndTo);
     }
 }

--- a/src/main/java/com/comeon/backend/date/infrastructure/dao/FixedDateMapper.java
+++ b/src/main/java/com/comeon/backend/date/infrastructure/dao/FixedDateMapper.java
@@ -1,10 +1,15 @@
 package com.comeon.backend.date.infrastructure.dao;
 
 import com.comeon.backend.date.query.dto.MeetingFixedDateSimple;
+import com.comeon.backend.date.query.dto.MeetingFixedDateSummary;
 import org.apache.ibatis.annotations.Mapper;
+
+import java.time.LocalDate;
+import java.util.List;
 
 @Mapper
 public interface FixedDateMapper {
 
     MeetingFixedDateSimple selectFixedDateSimple(Long meetingId);
+    List<MeetingFixedDateSummary> selectMeetingFixedDateSummary(Long userId, LocalDate searchStartFrom, LocalDate searchEndTo);
 }

--- a/src/main/java/com/comeon/backend/date/query/application/FixedDateQueryService.java
+++ b/src/main/java/com/comeon/backend/date/query/application/FixedDateQueryService.java
@@ -1,0 +1,48 @@
+package com.comeon.backend.date.query.application;
+
+import com.comeon.backend.date.query.dao.FixedDateDao;
+import com.comeon.backend.date.query.dto.MeetingFixedDateSummary;
+import com.comeon.backend.date.query.dto.MeetingFixedDatesResponse;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.time.LocalDate;
+import java.util.List;
+import java.util.stream.Collectors;
+
+@Slf4j
+@Service
+@RequiredArgsConstructor
+@Transactional(readOnly = true)
+public class FixedDateQueryService {
+
+    private final FixedDateDao fixedDateDao;
+
+    public MeetingFixedDatesResponse findMeetingFixedDates(Long userId, int baseYear, int baseMonth) {
+        LocalDate baseCalendar = LocalDate.of(baseYear, baseMonth, 1);
+        LocalDate startFrom = baseCalendar.minusMonths(6);
+        LocalDate endTo = baseCalendar.plusMonths(6).minusDays(1);
+
+        List<MeetingFixedDateSummary> meetingFixedDatesSummary =
+                fixedDateDao.findMeetingFixedDatesSummary(userId, startFrom, endTo);
+
+        return new MeetingFixedDatesResponse(
+                meetingFixedDatesSummary.stream()
+                        .collect(Collectors.groupingBy(
+                                summary -> summary.getFixedDate().getStartDate().getYear(),
+                                Collectors.groupingBy(
+                                        summary -> summary.getFixedDate().getStartDate().getMonthValue()
+                                )
+                        ))
+                        .entrySet().stream()
+                        .map(mapEntry -> new MeetingFixedDatesResponse.YearMeetings(
+                                mapEntry.getKey(),
+                                mapEntry.getValue().entrySet().stream()
+                                        .map(entry -> new MeetingFixedDatesResponse.MonthCalendar(entry.getKey(), entry.getValue()))
+                                        .collect(Collectors.toList())
+                        )).collect(Collectors.toList())
+        );
+    }
+}

--- a/src/main/java/com/comeon/backend/date/query/dao/FixedDateDao.java
+++ b/src/main/java/com/comeon/backend/date/query/dao/FixedDateDao.java
@@ -1,8 +1,13 @@
 package com.comeon.backend.date.query.dao;
 
 import com.comeon.backend.date.query.dto.MeetingFixedDateSimple;
+import com.comeon.backend.date.query.dto.MeetingFixedDateSummary;
+
+import java.time.LocalDate;
+import java.util.List;
 
 public interface FixedDateDao {
 
     MeetingFixedDateSimple findFixedDateSimple(Long meetingId);
+    List<MeetingFixedDateSummary> findMeetingFixedDatesSummary(Long userId, LocalDate searchStartFrom, LocalDate searchEndTo);
 }

--- a/src/main/java/com/comeon/backend/date/query/dto/MeetingFixedDateSummary.java
+++ b/src/main/java/com/comeon/backend/date/query/dto/MeetingFixedDateSummary.java
@@ -1,8 +1,11 @@
 package com.comeon.backend.date.query.dto;
 
+import com.fasterxml.jackson.annotation.JsonFormat;
 import lombok.AllArgsConstructor;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
+
+import java.time.LocalTime;
 
 @Getter
 @NoArgsConstructor
@@ -12,4 +15,7 @@ public class MeetingFixedDateSummary {
     private Long meetingId;
     private String meetingName;
     private FixedDateSimple fixedDate;
+
+    @JsonFormat(shape = JsonFormat.Shape.STRING, pattern = "HH:mm:ss")
+    private LocalTime meetingStartTime;
 }

--- a/src/main/java/com/comeon/backend/date/query/dto/MeetingFixedDateSummary.java
+++ b/src/main/java/com/comeon/backend/date/query/dto/MeetingFixedDateSummary.java
@@ -1,0 +1,15 @@
+package com.comeon.backend.date.query.dto;
+
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Getter
+@NoArgsConstructor
+@AllArgsConstructor
+public class MeetingFixedDateSummary {
+
+    private Long meetingId;
+    private String meetingName;
+    private FixedDateSimple fixedDate;
+}

--- a/src/main/java/com/comeon/backend/date/query/dto/MeetingFixedDatesResponse.java
+++ b/src/main/java/com/comeon/backend/date/query/dto/MeetingFixedDatesResponse.java
@@ -2,33 +2,28 @@ package com.comeon.backend.date.query.dto;
 
 import lombok.AllArgsConstructor;
 import lombok.Getter;
-import lombok.NoArgsConstructor;
 
-import java.util.ArrayList;
 import java.util.List;
 
 @Getter
-@NoArgsConstructor
 @AllArgsConstructor
 public class MeetingFixedDatesResponse {
 
-    private List<YearMeetings> result = new ArrayList<>();
+    private List<YearMeetings> result;
 
     @Getter
-    @NoArgsConstructor
     @AllArgsConstructor
     public static class YearMeetings {
 
         private Integer year;
-        private List<MonthCalendar> calendar = new ArrayList<>();
+        private List<MonthCalendar> calendar;
     }
 
     @Getter
-    @NoArgsConstructor
     @AllArgsConstructor
     public static class MonthCalendar {
 
         private Integer month;
-        private List<MeetingFixedDateSummary> meetings = new ArrayList<>();
+        private List<MeetingFixedDateSummary> meetings;
     }
 }

--- a/src/main/java/com/comeon/backend/date/query/dto/MeetingFixedDatesResponse.java
+++ b/src/main/java/com/comeon/backend/date/query/dto/MeetingFixedDatesResponse.java
@@ -1,0 +1,34 @@
+package com.comeon.backend.date.query.dto;
+
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+import java.util.ArrayList;
+import java.util.List;
+
+@Getter
+@NoArgsConstructor
+@AllArgsConstructor
+public class MeetingFixedDatesResponse {
+
+    private List<YearMeetings> result = new ArrayList<>();
+
+    @Getter
+    @NoArgsConstructor
+    @AllArgsConstructor
+    public static class YearMeetings {
+
+        private Integer year;
+        private List<MonthCalendar> calendar = new ArrayList<>();
+    }
+
+    @Getter
+    @NoArgsConstructor
+    @AllArgsConstructor
+    public static class MonthCalendar {
+
+        private Integer month;
+        private List<MeetingFixedDateSummary> meetings = new ArrayList<>();
+    }
+}

--- a/src/main/resources/mapper/meeting/meeting-fixed-date-mapper.xml
+++ b/src/main/resources/mapper/meeting/meeting-fixed-date-mapper.xml
@@ -21,4 +21,26 @@
         where m.meeting_id = #{meetingId};
     </select>
 
+    <resultMap id="MeetingFixedDateSummaryMap" type="com.comeon.backend.date.query.dto.MeetingFixedDateSummary">
+        <id column="meeting_id" property="meetingId"/>
+        <result column="meeting_name" property="meetingName"/>
+        <association property="fixedDate"
+                     javaType="com.comeon.backend.date.query.dto.FixedDateSimple">
+            <result column="meeting_start_date" property="startDate"/>
+            <result column="meeting_end_date" property="endDate"/>
+        </association>
+    </resultMap>
+    <select id="selectMeetingFixedDateSummary" resultMap="MeetingFixedDateSummaryMap">
+        select m.meeting_id   as meeting_id,
+               m.name         as meeting_name,
+               mfd.start_from as meeting_start_date,
+               mfd.end_to     as meeting_end_date
+        from meeting_fixed_date mfd
+                 left join meeting m on mfd.meeting_id = m.meeting_id
+                 left join meeting_member mm on m.meeting_id = mm.meeting_id
+        where mm.user_id = #{userId}
+          and mfd.start_from <![CDATA[>=]]> #{searchStartFrom}
+          and mfd.start_from <![CDATA[<=]]> #{searchEndTo}
+        order by mfd.start_from
+    </select>
 </mapper>

--- a/src/main/resources/mapper/meeting/meeting-fixed-date-mapper.xml
+++ b/src/main/resources/mapper/meeting/meeting-fixed-date-mapper.xml
@@ -24,6 +24,7 @@
     <resultMap id="MeetingFixedDateSummaryMap" type="com.comeon.backend.date.query.dto.MeetingFixedDateSummary">
         <id column="meeting_id" property="meetingId"/>
         <result column="meeting_name" property="meetingName"/>
+        <result column="meeting_start_time" property="meetingStartTime"/>
         <association property="fixedDate"
                      javaType="com.comeon.backend.date.query.dto.FixedDateSimple">
             <result column="meeting_start_date" property="startDate"/>
@@ -31,10 +32,11 @@
         </association>
     </resultMap>
     <select id="selectMeetingFixedDateSummary" resultMap="MeetingFixedDateSummaryMap">
-        select m.meeting_id   as meeting_id,
-               m.name         as meeting_name,
-               mfd.start_from as meeting_start_date,
-               mfd.end_to     as meeting_end_date
+        select m.meeting_id         as meeting_id,
+               m.name               as meeting_name,
+               mfd.start_from       as meeting_start_date,
+               mfd.end_to           as meeting_end_date,
+               m.meeting_start_time as meeting_start_time
         from meeting_fixed_date mfd
                  left join meeting m on mfd.meeting_id = m.meeting_id
                  left join meeting_member mm on m.meeting_id = mm.meeting_id

--- a/src/test/java/com/comeon/backend/api/date/FixedDateInfoApiControllerTest.java
+++ b/src/test/java/com/comeon/backend/api/date/FixedDateInfoApiControllerTest.java
@@ -187,8 +187,8 @@ public class FixedDateInfoApiControllerTest extends RestDocsTestSupport {
                                     getTitleAttributes("응답 필드"),
                                     PayloadDocumentation.fieldWithPath("meetingId").type(JsonFieldType.NUMBER).description("확정일을 조회한 모임의 식별값."),
                                     PayloadDocumentation.subsectionWithPath("fixedDate").type(JsonFieldType.OBJECT).description("모임의 확정일 정보.").optional(),
-                                    PayloadDocumentation.fieldWithPath("fixedDate.startDate").type(JsonFieldType.STRING).description("확정된 모임일의 시작 일자. +\nyyyy-MM-dd 형식의 날짜 지정."),
-                                    PayloadDocumentation.fieldWithPath("fixedDate.endDate").type(JsonFieldType.STRING).description("확정된 모임일의 시작 일자. +\nyyyy-MM-dd 형식의 날짜 지정.")
+                                    PayloadDocumentation.fieldWithPath("fixedDate.startDate").type(JsonFieldType.STRING).description("확정된 모임일의 시작 일자. +\nyyyy-MM-dd 형식으로 응답."),
+                                    PayloadDocumentation.fieldWithPath("fixedDate.endDate").type(JsonFieldType.STRING).description("확정된 모임일의 시작 일자. +\nyyyy-MM-dd 형식으로 응답.")
                             )
                     )
             );

--- a/src/test/java/com/comeon/backend/api/date/FixedDateInfoApiControllerTest.java
+++ b/src/test/java/com/comeon/backend/api/date/FixedDateInfoApiControllerTest.java
@@ -95,6 +95,52 @@ public class FixedDateInfoApiControllerTest extends RestDocsTestSupport {
     }
 
     @Nested
+    @DisplayName("모임일 삭제 API")
+    class meetingDateCancel {
+
+        String endpoint = baseEndpoint;
+
+        @Test
+        @DisplayName("given: 인증 필요, RequestBody - 모임 시작일, 종료일, 시작 시간 -> then: HTTP 200")
+        void success() throws Exception {
+            //given
+            BDDMockito.willDoNothing().given(dateConfirmFacade)
+                            .cancelMeetingConfirmedDate(BDDMockito.anyLong());
+
+            grantHost();
+
+            //when
+            ResultActions perform = mockMvc.perform(
+                    RestDocumentationRequestBuilders.delete(endpoint, mockMeetingId)
+                            .header(HttpHeaders.AUTHORIZATION, "Bearer " + currentRequestATK.getToken())
+                            .contentType(MediaType.APPLICATION_JSON)
+                            .characterEncoding(StandardCharsets.UTF_8)
+            );
+
+            //then
+            perform.andExpect(MockMvcResultMatchers.status().isOk());
+
+            // docs
+            perform.andDo(
+                    restDocs.document(
+                            RequestDocumentation.pathParameters(
+                                    getTitleAttributes(endpoint),
+                                    RequestDocumentation.parameterWithName("meeting-id").description("취소할 모임의 식별값")
+                            ),
+                            HeaderDocumentation.requestHeaders(
+                                    getTitleAttributes("요청 헤더"),
+                                    authorizationHeaderDescriptor
+                            ),
+                            PayloadDocumentation.responseFields(
+                                    getTitleAttributes("응답 필드"),
+                                    PayloadDocumentation.fieldWithPath("success").type(JsonFieldType.BOOLEAN).description("모임일 취소가 성공적으로 완료되었는지 여부")
+                            )
+                    )
+            );
+        }
+    }
+
+    @Nested
     @DisplayName("모임 확정일 조회 API")
     class fixedDateSimple {
 

--- a/src/test/java/com/comeon/backend/api/date/FixedDateListApiControllerTest.java
+++ b/src/test/java/com/comeon/backend/api/date/FixedDateListApiControllerTest.java
@@ -1,0 +1,129 @@
+package com.comeon.backend.api.date;
+
+import com.comeon.backend.api.support.utils.RestDocsTestSupport;
+import com.comeon.backend.date.api.FixedDateListApiController;
+import com.comeon.backend.date.query.application.FixedDateQueryService;
+import com.comeon.backend.date.query.dto.FixedDateSimple;
+import com.comeon.backend.date.query.dto.MeetingFixedDateSummary;
+import com.comeon.backend.date.query.dto.MeetingFixedDatesResponse;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+import org.mockito.BDDMockito;
+import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
+import org.springframework.boot.test.mock.mockito.MockBean;
+import org.springframework.http.HttpHeaders;
+import org.springframework.http.MediaType;
+import org.springframework.restdocs.headers.HeaderDocumentation;
+import org.springframework.restdocs.mockmvc.RestDocumentationRequestBuilders;
+import org.springframework.restdocs.payload.JsonFieldType;
+import org.springframework.restdocs.payload.PayloadDocumentation;
+import org.springframework.restdocs.request.RequestDocumentation;
+import org.springframework.test.web.servlet.ResultActions;
+import org.springframework.test.web.servlet.result.MockMvcResultMatchers;
+
+import java.nio.charset.StandardCharsets;
+import java.time.LocalDate;
+import java.time.LocalTime;
+import java.time.format.DateTimeFormatter;
+import java.util.List;
+
+@WebMvcTest(FixedDateListApiController.class)
+public class FixedDateListApiControllerTest extends RestDocsTestSupport {
+
+    @MockBean
+    FixedDateQueryService fixedDateQueryService;
+
+    String baseEndpoint = "/api/v1/meetings/date/confirm";
+
+    @Nested
+    @DisplayName("모임별 모임일 조회 API")
+    class meetingConfirmDates {
+
+        String endpoint = baseEndpoint;
+
+        @Test
+        @DisplayName("성공시 응답")
+        void success() throws Exception {
+            //given
+            BDDMockito.given(fixedDateQueryService.findMeetingFixedDates(BDDMockito.anyLong(), BDDMockito.anyInt(), BDDMockito.anyInt()))
+                    .willReturn(
+                            new MeetingFixedDatesResponse(
+                                    List.of(
+                                            new MeetingFixedDatesResponse.YearMeetings(
+                                                    2022,
+                                                    List.of(
+                                                            new MeetingFixedDatesResponse.MonthCalendar(
+                                                                    11,
+                                                                    List.of(
+                                                                            new MeetingFixedDateSummary(123L, "meeting-123", new FixedDateSimple(LocalDate.of(2022, 11, 4), LocalDate.of(2022, 11, 4)), LocalTime.of(8,0,0)),
+                                                                            new MeetingFixedDateSummary(142L, "meeting-142", new FixedDateSimple(LocalDate.of(2022, 11, 8), LocalDate.of(2022, 11, 8)), LocalTime.of(8,0,0))
+                                                                    )
+                                                            )
+                                                    )
+                                            ),
+                                            new MeetingFixedDatesResponse.YearMeetings(
+                                                    2023,
+                                                    List.of(
+                                                            new MeetingFixedDatesResponse.MonthCalendar(
+                                                                    1,
+                                                                    List.of(
+                                                                            new MeetingFixedDateSummary(211L, "meeting-211", new FixedDateSimple(LocalDate.of(2023, 1, 1), LocalDate.of(2023, 1, 1)), LocalTime.of(19,0,0)),
+                                                                            new MeetingFixedDateSummary(151L, "meeting-151", new FixedDateSimple(LocalDate.of(2023, 1, 17), LocalDate.of(2023, 1, 17)), LocalTime.of(21,0,0))
+                                                                    )
+                                                            ),
+                                                            new MeetingFixedDatesResponse.MonthCalendar(
+                                                                    2,
+                                                                    List.of(
+                                                                            new MeetingFixedDateSummary(111L, "meeting-111", new FixedDateSimple(LocalDate.of(2023, 2, 16), LocalDate.of(2023, 2, 16)), LocalTime.of(12,0,0)),
+                                                                            new MeetingFixedDateSummary(314L, "meeting-314", new FixedDateSimple(LocalDate.of(2023, 2, 25), LocalDate.of(2023, 2, 25)), LocalTime.of(13,0,0))
+                                                                    )
+                                                            )
+                                                    )
+                                            )
+                                    )
+                            )
+                    );
+
+            //when
+            ResultActions perform = mockMvc.perform(
+                    RestDocumentationRequestBuilders.get(endpoint)
+                            .param("calendar", LocalDate.now().format(DateTimeFormatter.ofPattern("yyyy-MM")))
+                            .header(HttpHeaders.AUTHORIZATION, "Bearer " + currentRequestATK.getToken())
+                            .contentType(MediaType.APPLICATION_JSON)
+                            .characterEncoding(StandardCharsets.UTF_8)
+            );
+
+            //then
+            perform.andExpect(MockMvcResultMatchers.status().isOk());
+
+            // docs
+            perform.andDo(
+                    restDocs.document(
+                            HeaderDocumentation.requestHeaders(
+                                    getTitleAttributes("요청 헤더"),
+                                    authorizationHeaderDescriptor
+                            ),
+                            RequestDocumentation.requestParameters(
+                                    getTitleAttributes("요청 파라미터"),
+                                    RequestDocumentation.parameterWithName("calendar").description("조회할 기준 년월. +\n해당 년월을 기준으로 이전 6개월, 이후 6개월 까지의 데이터를 조회합니다. +\n입력하지 않으면 현재 일자를 기준으로 조회합니다. +\nyyyy-MM 형식으로 작성해주세요. +\n ex) 2023-01").optional()
+                            ),
+                            PayloadDocumentation.responseFields(
+                                    getTitleAttributes("응답 필드"),
+                                    PayloadDocumentation.fieldWithPath("result").type(JsonFieldType.ARRAY).description("조회 결과 데이터를 담은 배열").optional(),
+                                    PayloadDocumentation.fieldWithPath("result[].year").type(JsonFieldType.NUMBER).description("조회 결과 데이터가 존재하는 년도"),
+                                    PayloadDocumentation.fieldWithPath("result[].calendar").type(JsonFieldType.ARRAY).description("해당 년도의 월별 모임일 정보 배열"),
+                                    PayloadDocumentation.fieldWithPath("result[].calendar[].month").type(JsonFieldType.NUMBER).description("조회 결과 데이터가 존재하는 월"),
+                                    PayloadDocumentation.fieldWithPath("result[].calendar[].meetings").type(JsonFieldType.ARRAY).description("해당 년월에 확정된 모임일 배열"),
+                                    PayloadDocumentation.fieldWithPath("result[].calendar[].meetings[].meetingId").type(JsonFieldType.NUMBER).description("모임 식별값"),
+                                    PayloadDocumentation.fieldWithPath("result[].calendar[].meetings[].meetingName").type(JsonFieldType.STRING).description("모임 이름"),
+                                    PayloadDocumentation.fieldWithPath("result[].calendar[].meetings[].fixedDate").type(JsonFieldType.OBJECT).description("모임일 정보"),
+                                    PayloadDocumentation.fieldWithPath("result[].calendar[].meetings[].fixedDate.startDate").type(JsonFieldType.STRING).description("모임 시작일 정보. +\nyyyy-MM-dd 형식으로 응답."),
+                                    PayloadDocumentation.fieldWithPath("result[].calendar[].meetings[].fixedDate.endDate").type(JsonFieldType.STRING).description("모임 종료일 정보. +\nyyyy-MM-dd 형식으로 응답."),
+                                    PayloadDocumentation.fieldWithPath("result[].calendar[].meetings[].meetingStartTime").type(JsonFieldType.STRING).description("모임 시작 시간. +\nHH:mm:ss 형식으로 응답.")
+                            )
+                    )
+            );
+        }
+    }
+}


### PR DESCRIPTION
- 모임일 등록 API 수정
  - (기존) 모임일 등록 API 이용시 기존 확정된 모임일이 존재하면 오류 발생
  - (변경 이후) 기존 등록된 모임일이 존재하면, 새로 요청된 모임일로 수정
- 모임일 취소 API 작성
  - 등록된 모임일을 삭제
- 모임별 모임일 조회 API 작성
  - 요청한 유저가 가입된 모임의 모임일을 조회하여 년월 별로 분류, 응답